### PR TITLE
NHSO-11828: Change API path from nhsapp to nhs-app

### DIFF
--- a/azure/project.yml
+++ b/azure/project.yml
@@ -1,7 +1,7 @@
 variables:
   service_name: nhs-app
   short_service_name: nhsa
-  service_base_path: nhsapp
+  service_base_path: nhs-app
   product_display_name: NHS App
   product_description: This is the NHS App service, where patents access their medical records and GP services
   spec_file: nhs-app.json

--- a/sandbox/api/openapi.yaml
+++ b/sandbox/api/openapi.yaml
@@ -134,7 +134,7 @@ x-nhsd-api-platform:
   meta:
     service_name: nhs-app
     short_service_name: nhsa
-    service_base_path: nhsapp
+    service_base_path: nhs-app
     product_display_name: NHS App
     product_description: This is the NHS App service, where patents access their medical
       records and GP services

--- a/specification/nhs-app.yaml
+++ b/specification/nhs-app.yaml
@@ -42,8 +42,8 @@ info:
 
     | Environment       | Base URL                                                       |
     | ----------------- | -------------------------------------------------------------- |
-    | Integration test  | `https://int.api.service.nhs.uk/nhsapp/`                       |
-    | Production        | `https://api.service.nhs.uk/nhsapp/`                           |
+    | Integration test  | `https://int.api.service.nhs.uk/nhs-app/`                      |
+    | Production        | `https://api.service.nhs.uk/nhs-app/`                          |
 
     ### Integration testing
     Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):
@@ -65,9 +65,9 @@ info:
     url: 'https://digital.nhs.uk/developer/help-and-support'
     email: app.onboarding@nhs.net
 servers:
-  - url: 'https://int.api.service.nhs.uk/nhsapp'
+  - url: 'https://int.api.service.nhs.uk/nhs-app'
     description: Integration test environment.
-  - url: 'https://api.service.nhs.uk/nhsapp'
+  - url: 'https://api.service.nhs.uk/nhs-app'
     description: 'Production environment.'
 tags:
   - name: communication
@@ -104,7 +104,7 @@ paths:
               schema:
                 type: string
               description: The location of the newly-created resource.
-              example: https://int.api.service.nhs.uk/nhsapp/communication/a2d10720-9e72-4ae4-be72-8cbe1be292d1
+              example: https://int.api.service.nhs.uk/nhs-app/communication/a2d10720-9e72-4ae4-be72-8cbe1be292d1
             X-Correlation-ID:
               schema:
                 type: string

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,7 +16,7 @@ terraform {
 module "nhs-app" {
   source                   = "github.com/NHSDigital/api-platform-service-module"
   name                     = "nhs-app"
-  path                     = "nhsapp"
+  path                     = "nhs-app"
   apigee_environment       = var.apigee_environment
   proxy_type               = (var.force_sandbox || length(regexall("sandbox", var.apigee_environment)) > 0) ? "sandbox" : "live"
   namespace                = var.namespace


### PR DESCRIPTION
## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change

This suggestion came out of the API specification review on 2020-11-17 - we should change the API path from nhsapp to nhs-app (snake-case) before it's too late.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
