### PR TITLE
NHSO-19711: Reduce the maximum number of recipients - integration test changes

### DIFF
--- a/tests/Nhs.App.Api.Integration.Tests/Nhs.App.Api.Integration.Tests/CommunicationHttpFunctionsFhirR4Tests.cs
+++ b/tests/Nhs.App.Api.Integration.Tests/Nhs.App.Api.Integration.Tests/CommunicationHttpFunctionsFhirR4Tests.cs
@@ -308,15 +308,15 @@ namespace Nhs.App.Api.Integration.Tests
 
         private static List<ResourceReference> BuildValidRecipient()
         {
-            var recipients = new List<ResourceReference>();
-
-            recipients.AddRange(_testConfiguration.SendToNhsNumbers.Select(nhsNumber => new ResourceReference
+            var recipient = new List<ResourceReference>
             {
-                Identifier = new Identifier(FhirR4IdentifierSystem.NhsNumber, nhsNumber),
-                Type = ResourceType.Patient.ToString()
-            }));
-
-            return recipients;
+                new ResourceReference
+                {
+                    Identifier = new Identifier(FhirR4IdentifierSystem.NhsNumber, _testConfiguration.SendToNhsNumber),
+                    Type = ResourceType.Patient.ToString()
+                }
+            };
+            return recipient;
         }
 
         private static async Task<CommunicationRequest> DeserializeFhirResponseAsync(HttpResponseMessage response)

--- a/tests/Nhs.App.Api.Integration.Tests/Nhs.App.Api.Integration.Tests/TestConfiguration.cs
+++ b/tests/Nhs.App.Api.Integration.Tests/Nhs.App.Api.Integration.Tests/TestConfiguration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Nhs.App.Api.Integration.Tests
@@ -13,20 +12,13 @@ namespace Nhs.App.Api.Integration.Tests
         public string IssuerKey { get; }
         public string PrivateKeyFilePath { get; }
         public string KidValue { get; }
-        public string ApigeeApiKey  { get; }
-        public string[] SendToNhsNumbers { get; }
-        public string SendToOdsCode { get; }
+        public string SendToNhsNumber { get; }
 
         public TestConfiguration(TestContext context)
         {
             _context = context;
             ApplicationUrl = GetTestPropertySetting("ApplicationUrl");
-            ApigeeApiKey = GetTestPropertySetting("ApigeeApiKey");
-            SendToNhsNumbers = GetTestPropertySetting("SendToNhsNumbers")
-                .Split(',')
-                .Select(x => x.Trim())
-                .ToArray();
-            SendToOdsCode = GetTestPropertySetting("SendToOdsCode");
+            SendToNhsNumber = GetTestPropertySetting("SendToNhsNumber");
             TokenEndpoint = GetTestPropertySetting("TokenEndpoint");
             IssuerKey = GetTestPropertySetting("IssuerKey");
             PrivateKeyFilePath = GetTestPropertySetting("PrivateKeyFilePath");

--- a/tests/Nhs.App.Api.Integration.Tests/Nhs.App.Api.Integration.Tests/test.runsettings
+++ b/tests/Nhs.App.Api.Integration.Tests/Nhs.App.Api.Integration.Tests/test.runsettings
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RunSettings>
-    <TestRunParameters>
-        <Parameter name="ApigeeApiKey" value="APP API KEY GOES HERE" />
-        <Parameter name="ApplicationUrl" value="https://internal-dev.api.service.nhs.uk/nhs-app/" />
-        <Parameter name="SendToNhsNumbers" value="9487416153,8061422395" />
-        <Parameter name="SendToOdsCode" value="A00002" />
-        <Parameter name="TokenEndpoint" value="https://internal-dev.api.service.nhs.uk/oauth2/token" />
-        <Parameter name="IssuerKey" value="APP API KEY GOES HERE" />
-        <Parameter name="PrivateKeyFilePath" value="PATH TO PRIVATE KEY FILE GOES HERE" />
-        <Parameter name="KidValue" value="KID VALUE GOES HERE" />
-    </TestRunParameters>
-</RunSettings>
+	<RunSettings>
+	    <TestRunParameters>
+	        <Parameter name="ApplicationUrl" value="https://internal-dev.api.service.nhs.uk/nhs-app/" />
+	        <Parameter name="SendToNhsNumber" value="9487416153" />
+	        <Parameter name="TokenEndpoint" value="https://internal-dev.api.service.nhs.uk/oauth2/token" />
+	        <Parameter name="IssuerKey" value="APP API KEY GOES HERE" />
+	        <Parameter name="PrivateKeyFilePath" value="PATH TO PRIVATE KEY FILE GOES HERE" />
+	        <Parameter name="KidValue" value="KID VALUE GOES HERE" />
+	    </TestRunParameters>
+	</RunSettings>


### PR DESCRIPTION
Integration test changes pertaining to NHSO-19711; reducing the maximum number of recipients per request from 100 to 1.

## Summary

* Changed integration tests to only send to a single recipient by NHS number
* Removed integration tests that send by ODS code (this feature is not supported)
* Removed redundant ApigeeApiKey setting (missed from NHSO-12653 changes)

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
