### PR TITLE
NHSO-24626: Realtime receipts exemplar spec fix - statusReason type

### DIFF
--- a/specifications-callbacks/realtime-receipts/components/schemas/requests/task.yaml
+++ b/specifications-callbacks/realtime-receipts/components/schemas/requests/task.yaml
@@ -47,9 +47,14 @@ properties:
       - completed
     example: 'completed'
   statusReason:
-    type: string
+    type: object
     description: For rejected receipts only, this property will contain an explanation of why the rejection occurred.
-    example: 'NHS number not found'
+    required:
+     - text
+    properties:
+      text:
+        type: string
+        example: 'NHS number not found'
   code:
     type: object
     description: Indication of the type of event that occurred.


### PR DESCRIPTION
## Realtime receipts exemplar spec fix - statusReason type

The exemplar OAS for realtime receipts incorrectly defined the statusReason field as a string. 
In fact it should be an object (it is a FHIR Codeable concept) - https://www.hl7.org/fhir/task-definitions.html#Task.statusReason

## Reviews Required
* [x] Dev
* [ ] Test
* [x] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
