### PR TITLE
NHSO-24626: Realtime receipts exemplar spec fix - FHIR identifier correction

### DIFF
--- a/specification/components/examples/responses/communication/report/200successReceipts.json
+++ b/specification/components/examples/responses/communication/report/200successReceipts.json
@@ -27,7 +27,7 @@
                     "value": "optional request reference"
                 },
                 {
-                    "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+                    "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
                     "value" : "882cc757-5096-4565-9779-af25a751a65f"
                 }
             ],
@@ -60,7 +60,7 @@
                     "value": "optional request reference"
                 },
                 {
-                    "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+                    "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
                     "value" : "882cc757-5096-4565-9779-af25a751a65f"
                 }
             ],
@@ -93,7 +93,7 @@
                     "value": "optional request reference"
                 },
                 {
-                    "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+                    "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
                     "value" : "882cc757-5096-4565-9779-af25a751a65f"
                 }
             ],
@@ -118,7 +118,7 @@
             "intent": "order",
             "identifier": [
                 {
-                    "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+                    "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
                     "value" : "410baa9d-0b7e-4120-af1b-2f5b2656edf9"
                 }
             ],
@@ -143,7 +143,7 @@
             "intent": "order",
             "identifier": [
                 {
-                    "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+                    "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
                     "value" : "410baa9d-0b7e-4120-af1b-2f5b2656edf9"
                 }
             ],
@@ -168,7 +168,7 @@
             "intent": "order",
             "identifier": [
                 {
-                    "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+                    "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
                     "value" : "410baa9d-0b7e-4120-af1b-2f5b2656edf9"
                 }
             ],
@@ -197,7 +197,7 @@
                     "value": "flu campaign 202208"
                 },
                 {
-                    "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+                    "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
                     "value" : "01389fa3-2cb9-4440-b075-c4902b526fbc"
                 }
             ],

--- a/specifications-callbacks/realtime-receipts/components/examples/requests/task/delivered.json
+++ b/specifications-callbacks/realtime-receipts/components/examples/requests/task/delivered.json
@@ -11,7 +11,7 @@
             "value": "optional request reference"
         },
         {
-            "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+            "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
             "value" : "8f7ec136-66eb-4a9e-97ca-5c7a53d2710c"
         } 
     ],

--- a/specifications-callbacks/realtime-receipts/components/examples/requests/task/notified.json
+++ b/specifications-callbacks/realtime-receipts/components/examples/requests/task/notified.json
@@ -11,7 +11,7 @@
             "value": "optional request reference"
         }, 
         {
-            "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+            "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
             "value" : "8f7ec136-66eb-4a9e-97ca-5c7a53d2710c"
         }
     ],

--- a/specifications-callbacks/realtime-receipts/components/examples/requests/task/read.json
+++ b/specifications-callbacks/realtime-receipts/components/examples/requests/task/read.json
@@ -11,7 +11,7 @@
             "value": "optional request reference"
         },
         {
-            "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+            "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
             "value" : "8f7ec136-66eb-4a9e-97ca-5c7a53d2710c"
         } 
     ],

--- a/specifications-callbacks/realtime-receipts/components/examples/requests/task/rejected.json
+++ b/specifications-callbacks/realtime-receipts/components/examples/requests/task/rejected.json
@@ -11,7 +11,7 @@
             "value": "optional request reference"
         },
         {
-            "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+            "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
             "value" : "8f7ec136-66eb-4a9e-97ca-5c7a53d2710c"
         } 
     ],

--- a/specifications-callbacks/realtime-receipts/components/examples/requests/task/unnotified.json
+++ b/specifications-callbacks/realtime-receipts/components/examples/requests/task/unnotified.json
@@ -11,7 +11,7 @@
             "value": "optional request reference"
         }, 
         {
-            "system" : "http://fhir.nhs.uk/Id/nhs-app-communication-id",
+            "system" : "https://fhir.nhs.uk/Id/nhs-app-communication-id",
             "value" : "8f7ec136-66eb-4a9e-97ca-5c7a53d2710c"
         }
     ],

--- a/specifications-callbacks/realtime-replies/components/examples/responses/freetext-replies-completed.json
+++ b/specifications-callbacks/realtime-replies/components/examples/responses/freetext-replies-completed.json
@@ -17,7 +17,7 @@
     "status": "completed", 
     "basedOn": [ {
             "identifier": {
-                    "system": "http://fhir.nhs.uk/Id/nhs-app-communication-id", 
+                    "system": "https://fhir.nhs.uk/Id/nhs-app-communication-id", 
                     "value": " 8f7ec136-66eb-4a9e-97ca-5c7a53d2710c"
                     } 
                 }

--- a/specifications-callbacks/realtime-replies/components/examples/responses/keyword-replies-completed.json
+++ b/specifications-callbacks/realtime-replies/components/examples/responses/keyword-replies-completed.json
@@ -23,7 +23,7 @@
     "status": "completed", 
     "basedOn": [ {
             "identifier": {
-                    "system": "http://fhir.nhs.uk/Id/nhs-app-communication-id", 
+                    "system": "https://fhir.nhs.uk/Id/nhs-app-communication-id", 
                     "value": " 8f7ec136-66eb-4a9e-97ca-5c7a53d2710c"
                     } 
                 }

--- a/specifications-callbacks/realtime-replies/components/schemas/requests/communicationrequest.yaml
+++ b/specifications-callbacks/realtime-replies/components/schemas/requests/communicationrequest.yaml
@@ -92,7 +92,7 @@ properties:
     example: completed
   basedOn:
     type: array
-    description: Contains the unique identifier of the communication, with system http://fhir.nhs.uk/Id/nhs-app-communication-id
+    description: Contains the unique identifier of the communication, with system https://fhir.nhs.uk/Id/nhs-app-communication-id
     minItems: 1
     maxItems: 1
     items:


### PR DESCRIPTION
## Realtime receipts exemplar spec fix - FHIR identifier correction
The realtime receipts exemplar specification examples referred to a FHIR identifier with system http://fhir.nhs.uk/Id/nhs-app-communication-id . This should be https://fhir.nhs.uk/Id/nhs-app-communication-id (i.e. https protocol, not http).


## Reviews Required
* [x] Dev
* [ ] Test
* [x] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
