### PR TITLE
NHSO-0000: Clarify that HTML encoded characters are not supported.

### DIFF
--- a/specification/components/schemas/Markdown.yaml
+++ b/specification/components/schemas/Markdown.yaml
@@ -35,6 +35,7 @@ description: |
     > Forcing a line-break &nbsp;&nbsp;<--(two spaces)  
     > Next line
 
+  Note that HTML encoded characters will not be decoded in the NHS App upon displaying them to the user.
 maxLength: 5000
 pattern: must not match <(.|\n)*?>
 example: You have a new appointment, please confirm you can attend. Open the Onboarded Third Party appointment here https://www.nhsapp.service.nhs.uk/appointments/hospital-appointments

--- a/specification/nhs-app.yaml
+++ b/specification/nhs-app.yaml
@@ -177,7 +177,7 @@ paths:
         
         When a recipient taps the native notification, the NHS App will open on the in-app messaging inbox page.
 
-        We support a subset of [Markdown](https://en.wikipedia.org/wiki/Markdown) for describing the body text of in-app messages. For details of the subset see the 'payload' property of the schema. The length of each in-app message is limited to 5000 characters, including any markdown characters and embedded hyperlinks.
+        We support a subset of [Markdown](https://en.wikipedia.org/wiki/Markdown) for describing the body text of in-app messages. For details of the subset see the 'payload' property of the schema. Note that HTML encoded characters will not be decoded on displaying them in the NHS App to the user. The length of each in-app message is limited to 5000 characters, including any markdown characters and embedded hyperlinks.
 
         The body of requests made to this endpoint are instances of [HL7 FHIR R4 CommunicationRequest](https://www.hl7.org/fhir/communicationrequest.html) resources. This schema documentation describes which fields on that resource we require and support. The API is tolerant of (but will silently ignore) any additionally supplied optional fields. For example, we do not currently honour the [doNotPerform](https://www.hl7.org/fhir/communicationrequest-definitions.html#CommunicationRequest.doNotPerform) or [priority](https://www.hl7.org/fhir/communicationrequest-definitions.html#CommunicationRequest.priority) fields.
 


### PR DESCRIPTION
## Summary
* Documentation change after feedback from NHS Notify


## Reviews Required
* [x] Dev
