### PR TITLE
NHSO-0000: Fix integration test failure

### DIFF
--- a/azure/templates/run-integration-tests.yml
+++ b/azure/templates/run-integration-tests.yml
@@ -37,6 +37,12 @@ steps:
       zipAfterPublish: false
       arguments: "--configuration Release -o Publish"
 
+  - task: Bash@3
+    displayName: Allow deployment to settle
+    inputs:
+      targetType: 'inline'
+      script: sleep 120s
+
   - task: DotNetCoreCLI@2
     displayName: Execute integration tests
     inputs:


### PR DESCRIPTION
A change in the APIM pipelines has introduced a race condition in pipeline execution. This change aims to allow the deployment to settle before integration tests are executed.