### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,9 @@ name: Build
 
 on: push
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: build

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,5 +1,8 @@
 name: PR Quality Check
 on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   link-ticket:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NHSDigital/nhs-app-api/security/code-scanning/3](https://github.com/NHSDigital/nhs-app-api/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/pr-lint.yaml` so the `GITHUB_TOKEN` is minimally scoped for this workflow.  
Best single fix without changing behavior:

- Set `contents: read` (safe baseline for checkout/repo metadata reads).
- Set `pull-requests: write` because the workflow posts a PR comment via `unsplash/comment-on-pr`.

Place this block right after `on:` (or before `jobs:`) so it applies to all jobs in the workflow.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
